### PR TITLE
Add typedef zt_t => struct zt_test *

### DIFF
--- a/examples/demo.c
+++ b/examples/demo.c
@@ -4,7 +4,7 @@
 
 #include <zt.h>
 
-static void passing_test(struct zt_test* t)
+static void passing_test(zt_t t)
 {
     zt_check(t, ZT_TRUE(2 + 2 == 4));
     zt_check(t, ZT_FALSE(2 + 2 == 5));
@@ -12,7 +12,7 @@ static void passing_test(struct zt_test* t)
     zt_check(t, ZT_CMP_BOOL(false, ==, false));
 }
 
-static void failing_test(struct zt_test* t)
+static void failing_test(zt_t t)
 {
     zt_check(t, ZT_TRUE(2 + 2 != 4));
     zt_check(t, ZT_FALSE(2 + 2 != 5));
@@ -20,7 +20,7 @@ static void failing_test(struct zt_test* t)
     zt_check(t, ZT_CMP_BOOL(false, ==, true));
 }
 
-static void badly_failing_test(struct zt_test* t)
+static void badly_failing_test(zt_t t)
 {
     zt_assert(t, ZT_CMP_INT(0, ==, -1));
     abort();

--- a/examples/test-root-user.c
+++ b/examples/test-root-user.c
@@ -3,7 +3,7 @@
 
 #include <zt.h>
 
-static void test_root_user(struct zt_test* t)
+static void test_root_user(zt_t t)
 {
     struct passwd* p = getpwnam("root");
     zt_assert(t, ZT_NOT_NULL(p));

--- a/man/libzt.3
+++ b/man/libzt.3
@@ -36,7 +36,7 @@ integers.
 .Bd -literal -offset indent
 #include <zt.h>
 
-static void test_math(zt_test* t)
+static void test_math(zt_t t)
 {
     zt_check(t, ZT_CMP_INT(2 + 2, ==, 4));
 }

--- a/man/zt_check.3
+++ b/man/zt_check.3
@@ -9,12 +9,12 @@
 .In zt.h
 .Ft void
 .Fo zt_check
-.Fa "zt_test *test"
+.Fa "zt_t t"
 .Fa "zt_claim claim"
 .Fc
 .Ft void
 .Fo zt_assert
-.Fa "zt_test *test"
+.Fa "zt_t t"
 .Fa "zt_claim claim"
 .Fc
 .Sh DESCRIPTION
@@ -62,7 +62,9 @@ One should not depend on neither C++ destructors nor the GCC cleanup function ex
 .Sh RETURN VALUES
 Neither function return anything. Failures are remembered inside the opaque
 .Nm zt_test
-structure passed by pointer as the first argument.
+structure passed by pointer (aka
+.Nm zt_t )
+as the first argument.
 .Sh EXAMPLES
 A minimal test program that looks up the UNIX user
 .Em root
@@ -73,7 +75,7 @@ and measures several properties of the returned record.
 
 #include <zt.h>
 
-static void test_root_user(zt_test* t) {
+static void test_root_user(zt_t t) {
     struct passwd *p = getpwnam("root");
     zt_assert(t, ZT_NOT_NULL(p));
     zt_check(t, ZT_CMP_CSTR(p->pw_name, ==, "root"));

--- a/man/zt_test.3
+++ b/man/zt_test.3
@@ -2,10 +2,11 @@
 .Os libzt 0.1
 .Dt zt_test 3 PRM
 .Sh NAME
-.Nm zt_test
+.Nm zt_test , zt_t
 .Nd private representation of test state
 .Sh SYNOPSIS
-struct zt_test; /* opaque type */
+.Vt struct zt_test
+.Vt typedef struct zt_test *zt_t
 .Sh DESCRIPTION
 .Nm
 is an opaque type that holds test state during execution. The test type is
@@ -15,6 +16,9 @@ and
 .Fn zt_assert
 functions, to alter test state.
 .Pp
+.Nm zt_t
+is is a typedef that cuts the test case boilerplate size.
+.Pp
 Internally
 .Nm
 stores the outcome of the test as well as data required for non-local exit
@@ -22,7 +26,9 @@ necessary when
 .Fn zt_assert
 fails.
 .Sh HISTORY
-.Nm
-first appeared in libzt 0.1
+.Nm zt_test
+first appeared in libzt 0.1,
+.Nm zt_t
+first appeared in libzt 0.1.1.
 .Sh AUTHORS
 .An "Zygmunt Krynicki" Aq Mt me@zygoon.pl

--- a/man/zt_test_case_func.3
+++ b/man/zt_test_case_func.3
@@ -7,7 +7,7 @@
 .Sh SYNOPSIS
 .Ft typedef void
 .Fo (*zt_test_case_func)
-.Fa "struct zt_test *"
+.Fa "zt_t"
 .Fc
 .Sh DESCRIPTION
 .Nm
@@ -15,7 +15,9 @@ is a pointer to a function implementing a single test case.
 .Sh IMPLEMENTATION NOTES
 The
 .Nm zt_test
-pointer argument is meant to be passed to
+pointer (aka
+.Nm zt_t )
+argument is meant to be passed to
 .Fn zt_check
 and
 .Fn zt_assert

--- a/man/zt_visit_test_case.3
+++ b/man/zt_visit_test_case.3
@@ -48,7 +48,7 @@ suite can contain any number of nested suites and test cases.
 .Bd -literal -offset indent
 #include <zt.h>
 
-static void test_foo(struct zt_test* t) {
+static void test_foo(zt_t t) {
     printf("foo invoked\\n");
 }
 
@@ -57,7 +57,7 @@ static void suite_inner(zt_visitor v) {
 }
 
 
-static void test_bar(struct zt_test* t) {
+static void test_bar(zt_t t) {
     printf("bar invoked\\n");
 }
 

--- a/zt-test.c
+++ b/zt-test.c
@@ -134,7 +134,7 @@ static void selftest_stream_eq_at(FILE* stream, const char* file,
     }
 }
 
-static void selftest_close_test(zt_test* t)
+static void selftest_close_test(zt_t t)
 {
     fclose(t->stream);
     t->stream = NULL;
@@ -275,7 +275,7 @@ static void test_boolean_as_text(void)
 
 /* claim verification */
 static bool selftest_passing_verify0_called;
-static bool selftest_passing_verify0(zt_test* t)
+static bool selftest_passing_verify0(zt_t t)
 {
     assert(t != NULL);
     selftest_passing_verify0_called = true;
@@ -283,7 +283,7 @@ static bool selftest_passing_verify0(zt_test* t)
 }
 
 static bool selftest_passing_verify1_called;
-static bool selftest_passing_verify1(zt_test* t, ZT_UNUSED zt_value arg1)
+static bool selftest_passing_verify1(zt_t t, ZT_UNUSED zt_value arg1)
 {
     assert(t != NULL);
     selftest_passing_verify1_called = true;
@@ -291,7 +291,7 @@ static bool selftest_passing_verify1(zt_test* t, ZT_UNUSED zt_value arg1)
 }
 
 static bool selftest_passing_verify2_called;
-static bool selftest_passing_verify2(zt_test* t, ZT_UNUSED zt_value arg1, ZT_UNUSED zt_value arg2)
+static bool selftest_passing_verify2(zt_t t, ZT_UNUSED zt_value arg1, ZT_UNUSED zt_value arg2)
 {
     assert(t != NULL);
     selftest_passing_verify2_called = true;
@@ -299,7 +299,7 @@ static bool selftest_passing_verify2(zt_test* t, ZT_UNUSED zt_value arg1, ZT_UNU
 }
 
 static bool selftest_passing_verify3_called;
-static bool selftest_passing_verify3(zt_test* t, ZT_UNUSED zt_value arg1, ZT_UNUSED zt_value arg2, ZT_UNUSED zt_value arg3)
+static bool selftest_passing_verify3(zt_t t, ZT_UNUSED zt_value arg1, ZT_UNUSED zt_value arg2, ZT_UNUSED zt_value arg3)
 {
     assert(t != NULL);
     selftest_passing_verify3_called = true;
@@ -1626,9 +1626,9 @@ static void test_quote_rune(void)
 }
 
 static bool selftest_stub_nested_test_case_visited;
-static void selftest_stub_nested_test_case(zt_test* test)
+static void selftest_stub_nested_test_case(zt_t t)
 {
-    assert(test != NULL);
+    assert(t != NULL);
     selftest_stub_nested_test_case_visited = true;
 }
 
@@ -1643,9 +1643,9 @@ static void selftest_stub_nested_test_suite(zt_visitor visitor)
 }
 
 static bool selftest_stub_test_case_visited;
-static void selftest_stub_test_case(zt_test* test)
+static void selftest_stub_test_case(zt_t t)
 {
-    assert(test != NULL);
+    assert(t != NULL);
     selftest_stub_test_case_visited = true;
 }
 
@@ -1716,7 +1716,7 @@ static void test_runner_visitor_visit_suite(void)
 }
 
 static bool selftest_case_pending_visited;
-static void selftest_case_pending(zt_test* t)
+static void selftest_case_pending(zt_t t)
 {
     selftest_case_pending_visited = true;
     assert(t->outcome == ZT_PENDING);
@@ -1745,7 +1745,7 @@ static void test_runner_visitor_visit_case_outcome_pending(void)
 }
 
 static bool selftest_case_passed_visited;
-static void selftest_case_passed(zt_test* t)
+static void selftest_case_passed(zt_t t)
 {
     selftest_case_passed_visited = true;
     t->outcome = ZT_PASSED;
@@ -1774,7 +1774,7 @@ static void test_runner_visitor_visit_case_outcome_passed(void)
 }
 
 static bool selftest_case_failed_visited;
-static void selftest_case_failed(zt_test* t)
+static void selftest_case_failed(zt_t t)
 {
     selftest_case_failed_visited = true;
     t->outcome = ZT_FAILED;
@@ -1803,7 +1803,7 @@ static void test_runner_visitor_visit_case_outcome_failed(void)
 }
 
 static bool selftest_case_bogus_outcome_visited;
-static void selftest_case_bogus_outcome(zt_test* t)
+static void selftest_case_bogus_outcome(zt_t t)
 {
     selftest_case_bogus_outcome_visited = true;
     t->outcome = 42;
@@ -1855,24 +1855,24 @@ static void test_main_listing_tests(void)
     zt_mock_stderr = NULL;
 }
 
-static void selftest_passing_check(zt_test* t)
+static void selftest_passing_check(zt_t t)
 {
     zt_check(t, ZT_TRUE(1));
     zt_check(t, ZT_CMP_INT(1, ==, 1));
 }
 
-static void selftest_failing_check(zt_test* t)
+static void selftest_failing_check(zt_t t)
 {
     zt_check(t, ZT_TRUE(0));
     zt_check(t, ZT_CMP_INT(1, !=, 1));
 }
 
-static void selftest_passing_assert(zt_test* t)
+static void selftest_passing_assert(zt_t t)
 {
     zt_assert(t, ZT_TRUE(1));
 }
 
-static void selftest_failing_assert(zt_test* t)
+static void selftest_failing_assert(zt_t t)
 {
     zt_assert(t, ZT_TRUE(0));
 }

--- a/zt.h
+++ b/zt.h
@@ -29,14 +29,15 @@ extern "C" {
 #define ZT_MINOR_VERSION 1
 
 struct zt_test;
-struct zt_visitor_vtab;
+typedef struct zt_test *zt_t;
 
+struct zt_visitor_vtab;
 typedef struct zt_visitor {
     void* id;
     const struct zt_visitor_vtab* vtab;
 } zt_visitor;
 
-typedef void (*zt_test_case_func)(struct zt_test*);
+typedef void (*zt_test_case_func)(zt_t);
 typedef void (*zt_test_suite_func)(zt_visitor);
 
 int zt_main(int argc, char** argv, char** envp, zt_test_suite_func tsuite);
@@ -149,8 +150,8 @@ typedef struct zt_claim {
     zt_location location;
 } zt_claim;
 
-void zt_check(struct zt_test* test, zt_claim claim);
-void zt_assert(struct zt_test* test, zt_claim claim);
+void zt_check(zt_t test, zt_claim claim);
+void zt_assert(zt_t test, zt_claim claim);
 
 zt_claim zt_true(zt_location location, zt_value value);
 zt_claim zt_false(zt_location location, zt_value value);


### PR DESCRIPTION
This typedef avoids the need to have struct zt_test as a public
type, so that it can be typedef'd away and abbreviates the argument
that all test functions need to have.

Relevant manual pages and examples are updated.