### PR TITLE
Rename zt_claim.verifier to .make_verifier

### DIFF
--- a/man/zt_claim.3
+++ b/man/zt_claim.3
@@ -7,9 +7,9 @@
 .Sh SYNOPSIS
 .In zt.h
 .Vt typedef struct zt_claim { ... } zt_claim;
-.Bl -column -offset indent "struct zt_verifier *(*)(void) " "verifier " Description"
+.Bl -column -offset indent "struct zt_verifier *(*)(void) " "make_verifier " Description"
 .It Sy Type Ta Sy Member Ta Sy Description
-.It Vt struct zt_verifier *(*)(void) Ta verifier Ta Verifier factory
+.It Vt struct zt_verifier *(*)(void) Ta make_verifier Ta Verifier factory
 .It Vt zt_value[3] Ta args Ta verifier arguments
 .It Vt zt_location Ta location Ta origin of the claim
 .El

--- a/zt-test.c
+++ b/zt-test.c
@@ -363,7 +363,7 @@ static void test_verify_claim0(void)
     claim.location.fname = "file.c";
     claim.location.lineno = 13;
     selftest_passing_verify0_called = true;
-    claim.verifier = selftest_passing_verifier0;
+    claim.make_verifier = selftest_passing_verifier0;
     result = zt_verify_claim(&t, &claim);
     assert(result == true);
     assert(selftest_passing_verify0_called == true);
@@ -380,7 +380,7 @@ static void test_verify_claim1(void)
     claim.location.fname = "file.c";
     claim.location.lineno = 13;
     selftest_passing_verify0_called = true;
-    claim.verifier = selftest_passing_verifier1;
+    claim.make_verifier = selftest_passing_verifier1;
     result = zt_verify_claim(&t, &claim);
     assert(result == true);
     assert(selftest_passing_verify1_called == true);
@@ -398,7 +398,7 @@ static void test_verify_claim2(void)
     claim.location.fname = "file.c";
     claim.location.lineno = 13;
     selftest_passing_verify2_called = true;
-    claim.verifier = selftest_passing_verifier2;
+    claim.make_verifier = selftest_passing_verifier2;
     result = zt_verify_claim(&t, &claim);
     assert(result == true);
     assert(selftest_passing_verify2_called == true);
@@ -417,7 +417,7 @@ static void test_verify_claim3(void)
     claim.location.fname = "file.c";
     claim.location.lineno = 13;
     selftest_passing_verify3_called = true;
-    claim.verifier = selftest_passing_verifier3;
+    claim.make_verifier = selftest_passing_verifier3;
     result = zt_verify_claim(&t, &claim);
     assert(result == true);
     assert(selftest_passing_verify3_called == true);
@@ -438,7 +438,7 @@ static void test_verify_bogus_claim4(void)
     zt_claim claim;
     zt_test t = selftest_make_test();
     memset(&claim, 0, sizeof claim);
-    claim.verifier = selftest_bogus_verifier4;
+    claim.make_verifier = selftest_bogus_verifier4;
     claim.location.fname = "file.c";
     claim.location.lineno = 13;
     result = zt_verify_claim(&t, &claim);
@@ -457,7 +457,7 @@ static void test_verify_mismatch_claim1of1(void)
     claim.location.fname = "file.c";
     claim.location.lineno = 13;
     selftest_passing_verify1_called = false;
-    claim.verifier = selftest_passing_verifier1;
+    claim.make_verifier = selftest_passing_verifier1;
     result = zt_verify_claim(&t, &claim);
     assert(result == false);
     assert(selftest_passing_verify1_called == false);
@@ -476,7 +476,7 @@ static void test_verify_mismatch_claim1of2(void)
     claim.location.fname = "file.c";
     claim.location.lineno = 13;
     selftest_passing_verify2_called = false;
-    claim.verifier = selftest_passing_verifier2;
+    claim.make_verifier = selftest_passing_verifier2;
     result = zt_verify_claim(&t, &claim);
     assert(result == false);
     assert(selftest_passing_verify2_called == false);
@@ -495,7 +495,7 @@ static void test_verify_mismatch_claim2of2(void)
     claim.location.fname = "file.c";
     claim.location.lineno = 13;
     selftest_passing_verify2_called = false;
-    claim.verifier = selftest_passing_verifier2;
+    claim.make_verifier = selftest_passing_verifier2;
     result = zt_verify_claim(&t, &claim);
     assert(result == false);
     assert(selftest_passing_verify2_called == false);
@@ -515,7 +515,7 @@ static void test_verify_mismatch_claim1of3(void)
     claim.location.fname = "file.c";
     claim.location.lineno = 13;
     selftest_passing_verify3_called = false;
-    claim.verifier = selftest_passing_verifier3;
+    claim.make_verifier = selftest_passing_verifier3;
     result = zt_verify_claim(&t, &claim);
     assert(result == false);
     assert(selftest_passing_verify3_called == false);
@@ -535,7 +535,7 @@ static void test_verify_mismatch_claim2of3(void)
     claim.location.fname = "file.c";
     claim.location.lineno = 13;
     selftest_passing_verify3_called = false;
-    claim.verifier = selftest_passing_verifier3;
+    claim.make_verifier = selftest_passing_verifier3;
     result = zt_verify_claim(&t, &claim);
     assert(result == false);
     assert(selftest_passing_verify3_called == false);
@@ -555,7 +555,7 @@ static void test_verify_mismatch_claim3of3(void)
     claim.location.fname = "file.c";
     claim.location.lineno = 13;
     selftest_passing_verify3_called = false;
-    claim.verifier = selftest_passing_verifier3;
+    claim.make_verifier = selftest_passing_verifier3;
     result = zt_verify_claim(&t, &claim);
     assert(result == false);
     assert(selftest_passing_verify3_called == false);
@@ -1429,7 +1429,7 @@ static void test_ZT_TRUE(void)
     zt_claim claim = ZT_TRUE(1 > 0);
     assert(strcmp(claim.location.fname, __FILE__) == 0);
     assert(claim.location.lineno == __LINE__ - 2);
-    assert(claim.verifier == zt_verifier_for_true);
+    assert(claim.make_verifier == zt_verifier_for_true);
     assert(zt_value_kind_of(claim.args[0]) == ZT_BOOLEAN);
     assert(claim.args[0].as.boolean == true);
     assert(strcmp(zt_source_of(claim.args[0]), "1 > 0") == 0);
@@ -1440,7 +1440,7 @@ static void test_ZT_FALSE(void)
     zt_claim claim = ZT_FALSE(0 < 1);
     assert(strcmp(claim.location.fname, __FILE__) == 0);
     assert(claim.location.lineno == __LINE__ - 2);
-    assert(claim.verifier == zt_verifier_for_false);
+    assert(claim.make_verifier == zt_verifier_for_false);
     assert(zt_value_kind_of(claim.args[0]) == ZT_BOOLEAN);
     assert(claim.args[0].as.boolean == true);
     assert(strcmp(zt_source_of(claim.args[0]), "0 < 1") == 0);
@@ -1451,7 +1451,7 @@ static void test_ZT_CMP_BOOL(void)
     zt_claim claim = ZT_CMP_BOOL(true, ==, 1 == 1);
     assert(strcmp(claim.location.fname, __FILE__) == 0);
     assert(claim.location.lineno == __LINE__ - 2);
-    assert(claim.verifier == zt_verifier_for_boolean_relation);
+    assert(claim.make_verifier == zt_verifier_for_boolean_relation);
 
     assert(zt_value_kind_of(claim.args[0]) == ZT_BOOLEAN);
     assert(claim.args[0].as.boolean == true);
@@ -1476,7 +1476,7 @@ static void test_ZT_CMP_RUNE(void)
     claim = ZT_CMP_RUNE(a, ==, b);
     assert(strcmp(claim.location.fname, __FILE__) == 0);
     assert(claim.location.lineno == __LINE__ - 2);
-    assert(claim.verifier == zt_verifier_for_rune_relation);
+    assert(claim.make_verifier == zt_verifier_for_rune_relation);
 
     assert(zt_value_kind_of(claim.args[0]) == ZT_RUNE);
     assert(claim.args[0].as.integer == 'a');
@@ -1501,7 +1501,7 @@ static void test_ZT_CMP_INT(void)
     claim = ZT_CMP_INT(a, ==, b);
     assert(strcmp(claim.location.fname, __FILE__) == 0);
     assert(claim.location.lineno == __LINE__ - 2);
-    assert(claim.verifier == zt_verifier_for_integer_relation);
+    assert(claim.make_verifier == zt_verifier_for_integer_relation);
 
     assert(zt_value_kind_of(claim.args[0]) == ZT_INTEGER);
     assert(claim.args[0].as.integer == 1);
@@ -1526,7 +1526,7 @@ static void test_ZT_CMP_UINT(void)
     claim = ZT_CMP_UINT(a, ==, b);
     assert(strcmp(claim.location.fname, __FILE__) == 0);
     assert(claim.location.lineno == __LINE__ - 2);
-    assert(claim.verifier == zt_verifier_for_unsigned_relation);
+    assert(claim.make_verifier == zt_verifier_for_unsigned_relation);
 
     assert(zt_value_kind_of(claim.args[0]) == ZT_UNSIGNED);
     assert(claim.args[0].as.unsigned_integer == 1);
@@ -1551,7 +1551,7 @@ static void test_ZT_CMP_CSTR(void)
     claim = ZT_CMP_CSTR(a, ==, b);
     assert(strcmp(claim.location.fname, __FILE__) == 0);
     assert(claim.location.lineno == __LINE__ - 2);
-    assert(claim.verifier == zt_verifier_for_string_relation);
+    assert(claim.make_verifier == zt_verifier_for_string_relation);
 
     assert(zt_value_kind_of(claim.args[0]) == ZT_STRING);
     assert(strcmp(claim.args[0].as.string, "foo") == 0);
@@ -1572,7 +1572,7 @@ static void test_ZT_NULL(void)
     zt_claim claim = ZT_NULL(p);
     assert(strcmp(claim.location.fname, __FILE__) == 0);
     assert(claim.location.lineno == __LINE__ - 2);
-    assert(claim.verifier == zt_verifier_for_null);
+    assert(claim.make_verifier == zt_verifier_for_null);
 
     assert(zt_value_kind_of(claim.args[0]) == ZT_POINTER);
     assert(claim.args[0].as.pointer == NULL);
@@ -1591,7 +1591,7 @@ static void test_ZT_NOT_NULL(void)
     zt_claim claim = ZT_NOT_NULL(p);
     assert(strcmp(claim.location.fname, __FILE__) == 0);
     assert(claim.location.lineno == __LINE__ - 2);
-    assert(claim.verifier == zt_verifier_for_not_null);
+    assert(claim.make_verifier == zt_verifier_for_not_null);
 
     assert(zt_value_kind_of(claim.args[0]) == ZT_POINTER);
     assert(claim.args[0].as.pointer == &p);

--- a/zt.c
+++ b/zt.c
@@ -431,7 +431,7 @@ static zt_outcome zt_run_tests_from(FILE* stream_out, FILE* stream_err, bool ver
 
 static bool zt_verify_claim(zt_test* test, const zt_claim* claim)
 {
-    zt_verifier verifier = claim->verifier();
+    zt_verifier verifier = claim->make_verifier();
     test->location = claim->location;
     switch (verifier.nargs) {
     case 0:
@@ -574,7 +574,7 @@ zt_claim zt_true(zt_location location, zt_value value)
     zt_claim claim;
     memset(&claim, 0, sizeof claim);
     claim.location = location;
-    claim.verifier = zt_verifier_for_true;
+    claim.make_verifier = zt_verifier_for_true;
     claim.args[0] = value;
     return claim;
 }
@@ -603,7 +603,7 @@ zt_claim zt_false(zt_location location, zt_value value)
     zt_claim claim;
     memset(&claim, 0, sizeof claim);
     claim.location = location;
-    claim.verifier = zt_verifier_for_false;
+    claim.make_verifier = zt_verifier_for_false;
     claim.args[0] = value;
     return claim;
 }
@@ -666,7 +666,7 @@ zt_claim zt_cmp_bool(zt_location location, zt_value left, zt_value rel, zt_value
     zt_claim claim;
     memset(&claim, 0, sizeof claim);
     claim.location = location;
-    claim.verifier = zt_verifier_for_boolean_relation;
+    claim.make_verifier = zt_verifier_for_boolean_relation;
     claim.args[0] = left;
     claim.args[1] = rel;
     claim.args[2] = right;
@@ -763,7 +763,7 @@ zt_claim zt_cmp_rune(zt_location location, zt_value left, zt_value rel, zt_value
     zt_claim claim;
     memset(&claim, 0, sizeof claim);
     claim.location = location;
-    claim.verifier = zt_verifier_for_rune_relation;
+    claim.make_verifier = zt_verifier_for_rune_relation;
     claim.args[0] = left;
     claim.args[1] = rel;
     claim.args[2] = right;
@@ -851,7 +851,7 @@ zt_claim zt_cmp_int(zt_location location, zt_value left, zt_value rel, zt_value 
     zt_claim claim;
     memset(&claim, 0, sizeof claim);
     claim.location = location;
-    claim.verifier = zt_verifier_for_integer_relation;
+    claim.make_verifier = zt_verifier_for_integer_relation;
     claim.args[0] = left;
     claim.args[1] = rel;
     claim.args[2] = right;
@@ -940,7 +940,7 @@ zt_claim zt_cmp_uint(zt_location location, zt_value left, zt_value rel, zt_value
     zt_claim claim;
     memset(&claim, 0, sizeof claim);
     claim.location = location;
-    claim.verifier = zt_verifier_for_unsigned_relation;
+    claim.make_verifier = zt_verifier_for_unsigned_relation;
     claim.args[0] = left;
     claim.args[1] = rel;
     claim.args[2] = right;
@@ -1041,7 +1041,7 @@ zt_claim zt_cmp_cstr(zt_location location, zt_value left, zt_value rel, zt_value
     zt_claim claim;
     memset(&claim, 0, sizeof claim);
     claim.location = location;
-    claim.verifier = zt_verifier_for_string_relation;
+    claim.make_verifier = zt_verifier_for_string_relation;
     claim.args[0] = left;
     claim.args[1] = rel;
     claim.args[2] = right;
@@ -1073,7 +1073,7 @@ zt_claim zt_null(zt_location location, zt_value value)
     zt_claim claim;
     memset(&claim, 0, sizeof claim);
     claim.location = location;
-    claim.verifier = zt_verifier_for_null;
+    claim.make_verifier = zt_verifier_for_null;
     claim.args[0] = value;
     return claim;
 }
@@ -1102,7 +1102,7 @@ zt_claim zt_not_null(zt_location location, zt_value value)
     zt_claim claim;
     memset(&claim, 0, sizeof claim);
     claim.location = location;
-    claim.verifier = zt_verifier_for_not_null;
+    claim.make_verifier = zt_verifier_for_not_null;
     claim.args[0] = value;
     return claim;
 }

--- a/zt.h
+++ b/zt.h
@@ -144,8 +144,7 @@ static inline zt_location zt_location_at(const char* fname, int lineno)
 
 struct zt_verifier;
 typedef struct zt_claim {
-    /* TODO: rename verifier to make_verifier */
-    struct zt_verifier (*verifier)(void);
+    struct zt_verifier (*make_verifier)(void);
     zt_value args[3];
     zt_location location;
 } zt_claim;


### PR DESCRIPTION
There was a TODO to rename this field and I forgot to do this ahead of
the 0.1 release.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>