### PR TITLE
Allow using pointers to constants in zt_pack_null

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Changes in 0.3:
+
+ * Pointers captured in zt_value by zt_pack_pointer() are now constant.
+   This allows testing pointers to constants with ZT_NULL and ZT_NOT_NULL.
+   This does not impact the ABI.
+
 Changes in 0.2:
 
  * Argument type to all unit test functions was typedef'd

--- a/man/zt_pack_pointer.3
+++ b/man/zt_pack_pointer.3
@@ -8,7 +8,7 @@
 .In zt.h
 .Ft zt_value
 .Fo zt_pack_pointer
-.Fa "void *value"
+.Fa "const void *value"
 .Fa "const char *source"
 .Fc
 .Sh DESCRIPTION

--- a/man/zt_value.3
+++ b/man/zt_value.3
@@ -17,7 +17,7 @@
 .It Vt unsigned Ta as.unsigned_integer Ta Value when used as ZT_UNSIGNED
 .It Vt int Ta as.rune Ta Value when used as ZT_RUNE
 .It Vt const char * Ta as.string Ta Value when used as ZT_STRING
-.It Vt void * Ta as.pointer Ta Value when used as ZT_POINTER
+.It Vt const void * Ta as.pointer Ta Value when used as ZT_POINTER
 .El
 .Pp
 .Vt typedef enum zt_value_kind { ... } zt_value_kind;

--- a/zt.h
+++ b/zt.h
@@ -65,7 +65,7 @@ typedef struct zt_value {
         int integer;
         unsigned unsigned_integer;
         const char* string;
-        void* pointer;
+        const void* pointer;
     } as;
     const char* source;
     zt_value_kind kind;
@@ -118,7 +118,7 @@ static inline zt_value zt_pack_string(const char* value, const char* source)
     return v;
 }
 
-static inline zt_value zt_pack_pointer(void* value, const char* source)
+static inline zt_value zt_pack_pointer(const void* value, const char* source)
 {
     zt_value v;
     v.as.pointer = value;


### PR DESCRIPTION
I bumped into this while writing tests to libzc which uses
constants extensively. This fortunately does not impact the ABI in any way.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>