### PR TITLE
Add support for comparing pointers with ZT_CMP_PTR

### DIFF
--- a/.makefiles/Makefile.UNIX.mk
+++ b/.makefiles/Makefile.UNIX.mk
@@ -171,14 +171,15 @@ dist:: $(NAME)_$(VERSION).tar.gz
 $(NAME)_$(VERSION).tar.gz: $(sort $(addprefix $(srcdir)/, \
 	zt.c zt.h zt-test.c libzt.map libzt.export_list \
 	man/ZT_CMP_BOOL.3 man/ZT_CMP_INT.3 man/ZT_CMP_RUNE.3 man/ZT_CMP_UINT.3 \
-	man/ZT_CURRENT_LOCATION.3 man/ZT_FALSE.3 man/ZT_NOT_NULL.3 \
-	man/ZT_NULL.3 man/ZT_TRUE.3 man/libzt-test.1 man/libzt.3 man/zt_check.3 \
-	man/zt_claim.3 man/zt_location.3 man/zt_location_at.3 man/zt_main.3 \
-	man/zt_pack_boolean.3 man/zt_pack_integer.3 man/zt_pack_nothing.3 \
-	man/zt_pack_pointer.3 man/zt_pack_rune.3 man/zt_pack_string.3 \
-	man/zt_pack_unsigned.3 man/zt_test.3 man/zt_test_case_func.3 \
-	man/zt_test_suite_func.3 man/zt_value.3 man/zt_visit_test_case.3 \
-	man/zt_visitor.3 examples/demo.c examples/test-root-user.c \
+	man/ZT_CMP_PTR.3 man/ZT_CURRENT_LOCATION.3 man/ZT_FALSE.3 \
+	man/ZT_NOT_NULL.3 man/ZT_NULL.3 man/ZT_TRUE.3 man/libzt-test.1 \
+	man/libzt.3 man/zt_check.3 man/zt_claim.3 man/zt_location.3 \
+	man/zt_location_at.3 man/zt_main.3 man/zt_pack_boolean.3 \
+	man/zt_pack_integer.3 man/zt_pack_nothing.3 man/zt_pack_pointer.3 \
+	man/zt_pack_rune.3 man/zt_pack_string.3 man/zt_pack_unsigned.3 \
+	man/zt_test.3 man/zt_test_case_func.3 man/zt_test_suite_func.3 \
+	man/zt_value.3 man/zt_visit_test_case.3 man/zt_visitor.3 examples/demo.c \
+	examples/test-root-user.c \
 	examples/GNUmakefile configure GNUmakefile .makefiles/Makefile.Darwin.mk \
 	.makefiles/Makefile.FreeBSD.mk .makefiles/Makefile.Linux.mk \
 	.makefiles/Makefile.NetBSD.mk .makefiles/Makefile.OpenBSD.mk \

--- a/libzt.export_list
+++ b/libzt.export_list
@@ -3,6 +3,7 @@ _zt_check
 _zt_cmp_bool
 _zt_cmp_cstr
 _zt_cmp_int
+_zt_cmp_ptr
 _zt_cmp_rune
 _zt_cmp_uint
 _zt_false

--- a/libzt.map
+++ b/libzt.map
@@ -5,6 +5,7 @@ VERS_0_1 {
 		zt_cmp_bool;
 		zt_cmp_cstr;
 		zt_cmp_int;
+		zt_cmp_ptr;
 		zt_cmp_rune;
 		zt_cmp_uint;
 		zt_false;

--- a/man/ZT_CMP_BOOL.3
+++ b/man/ZT_CMP_BOOL.3
@@ -56,6 +56,7 @@ or to
 .Xr ZT_CMP_CHAR 3 ,
 .Xr ZT_CMP_CSTR 3 ,
 .Xr ZT_CMP_INT 3 ,
+.Xr ZT_CMP_PTR 3 ,
 .Xr ZT_CMP_UINT 3 ,
 .Xr ZT_FALSE 3 ,
 .Xr ZT_NOT_NULL 3 ,

--- a/man/ZT_CMP_INT.3
+++ b/man/ZT_CMP_INT.3
@@ -54,6 +54,7 @@ or to
 .Xr ZT_CMP_BOOL 3 ,
 .Xr ZT_CMP_CHAR 3 ,
 .Xr ZT_CMP_CSTR 3 ,
+.Xr ZT_CMP_PTR 3 ,
 .Xr ZT_CMP_UINT 3 ,
 .Xr ZT_FALSE 3 ,
 .Xr ZT_NOT_NULL 3 ,

--- a/man/ZT_CMP_PTR.3
+++ b/man/ZT_CMP_PTR.3
@@ -1,44 +1,40 @@
-.Dd January 12, 2020
+.Dd March 12, 2020
 .Os libzt 0.1
-.Dt ZT_CMP_UINT 3 PRM
+.Dt ZT_CMP_PTR 3 PRM
 .Sh NAME
-.Nm ZT_CMP_UINT ,
-.Nm zt_cmp_uint
-.Nd construct a claim of a relation between two unsigned integers
+.Nm ZT_CMP_PTR ,
+.Nm zt_cmp_int
+.Nd construct a claim of a relation between two pointers
 .Sh SYNOPSIS
 .In zt.h
 .Bd -literal
-#define ZT_CMP_UINT(left, rel, right) \\
-  zt_cmp_int( \\
+#define ZT_CMP_PTR(left, rel, right) \\
+  zt_cmp_ptr( \\
     ZT_CURRENT_LOCATION(), \\
-    zt_pack_unsigned((left), (#left)), \\
+    zt_pack_pointer((left), (#left)), \\
     zt_pack_string((#rel), (#rel)), \\
-    zt_pack_unsigned((right), (#right)))
+    zt_pack_pointer((right), (#right)))
 .Ed
 .Ft zt_claim
-.Fo zt_cmp_uint
+.Fo zt_cmp_ptr
 .Fa "zt_location location"
 .Fa "zt_value left"
 .Fa "zt_value rel"
 .Fa "zt_value right"
 .Fc
 .Sh DESCRIPTION
-.Fn zt_cmp_uint
-constructs a claim of a relation between two unsigned integers. It should be
-used through the macro
-.Fn ZT_CMP_UINT
+.Fn zt_cmp_ptr
+constructs a claim of a relation between two integers. It should be used
+through the macro
+.Fn ZT_CMP_PTR
 which passes source code location and packs arguments.
 .Pp
-The relation must be one of
+The relation must be either
 .Em == ,
-.Em != ,
-.Em < ,
-.Em <= ,
-.Em >
 or
-.Em >= .
+.Em !=
 .Sh IMPLEMENTATION NOTES
-.Fn ZT_CMP_UINT
+.Fn ZT_CMP_PTR
 evaluates
 .Em left
 and
@@ -63,9 +59,9 @@ or to
 .Xr zt_check 3 ,
 .Sh HISTORY
 The
-.Fn ZT_CMP_UINT
+.Fn ZT_CMP_PTR
 macro and the
-.Fn zt_cmp_uint
-function first appeared in libzt 0.1
+.Fn zt_cmp_ptr
+function first appeared in libzt 0.3
 .Sh AUTHORS
 .An "Zygmunt Krynicki" Aq Mt me@zygoon.pl

--- a/man/ZT_CMP_RUNE.3
+++ b/man/ZT_CMP_RUNE.3
@@ -54,6 +54,7 @@ or to
 .Xr ZT_CMP_BOOL 3 ,
 .Xr ZT_CMP_CHAR 3 ,
 .Xr ZT_CMP_CSTR 3 ,
+.Xr ZT_CMP_PTR 3 ,
 .Xr ZT_CMP_UINT 3 ,
 .Xr ZT_FALSE 3 ,
 .Xr ZT_NOT_NULL 3 ,

--- a/man/ZT_FALSE.3
+++ b/man/ZT_FALSE.3
@@ -45,6 +45,7 @@ or to
 .Xr ZT_CMP_CHAR 3 ,
 .Xr ZT_CMP_CSTR 3 ,
 .Xr ZT_CMP_INT 3 ,
+.Xr ZT_CMP_PTR 3 ,
 .Xr ZT_CMP_UINT 3 ,
 .Xr ZT_FALSE 3 ,
 .Xr ZT_NOT_NULL 3 ,

--- a/man/ZT_NOT_NULL.3
+++ b/man/ZT_NOT_NULL.3
@@ -52,6 +52,7 @@ or to
 .Xr ZT_CMP_CHAR 3 ,
 .Xr ZT_CMP_CSTR 3 ,
 .Xr ZT_CMP_INT 3 ,
+.Xr ZT_CMP_PTR 3 ,
 .Xr ZT_CMP_UINT 3 ,
 .Xr ZT_FALSE 3 ,
 .Xr ZT_NOT_NULL 3 ,

--- a/man/ZT_NULL.3
+++ b/man/ZT_NULL.3
@@ -51,6 +51,7 @@ or to
 .Xr ZT_CMP_CHAR 3 ,
 .Xr ZT_CMP_CSTR 3 ,
 .Xr ZT_CMP_INT 3 ,
+.Xr ZT_CMP_PTR 3 ,
 .Xr ZT_CMP_UINT 3 ,
 .Xr ZT_FALSE 3 ,
 .Xr ZT_NOT_NULL 3 ,

--- a/man/ZT_TRUE.3
+++ b/man/ZT_TRUE.3
@@ -50,6 +50,7 @@ or to
 .Xr ZT_CMP_CHAR 3 ,
 .Xr ZT_CMP_CSTR 3 ,
 .Xr ZT_CMP_INT 3 ,
+.Xr ZT_CMP_PTR 3 ,
 .Xr ZT_CMP_UINT 3 ,
 .Xr ZT_FALSE 3 ,
 .Xr ZT_NOT_NULL 3 ,

--- a/man/zt_check.3
+++ b/man/zt_check.3
@@ -95,6 +95,7 @@ int main(int argc, char** argv, char** envp) {
 .Xr ZT_CMP_BOOL 3 ,
 .Xr ZT_CMP_CSTR 3 ,
 .Xr ZT_CMP_INT 3 ,
+.Xr ZT_CMP_PTR 3 ,
 .Xr ZT_CMP_UINT 3 ,
 .Xr ZT_FALSE 3 ,
 .Xr ZT_NOT_NULL 3 ,

--- a/zt.h
+++ b/zt.h
@@ -207,6 +207,13 @@ zt_claim zt_not_null(zt_location location, zt_value value);
         zt_pack_string(#rel, #rel),    \
         zt_pack_string((right), #right))
 
+#define ZT_CMP_PTR(left, rel, right)    \
+    zt_cmp_ptr(                         \
+        ZT_CURRENT_LOCATION(),          \
+        zt_pack_pointer((left), #left), \
+        zt_pack_string(#rel, #rel),     \
+        zt_pack_pointer((right), #right))
+
 #define ZT_NULL(value)         \
     zt_null(                   \
         ZT_CURRENT_LOCATION(), \


### PR DESCRIPTION
Only == and != relations are supported. The set of manual pages,
documentation, symbol export maps and unit-tests are all updated.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>