### PR TITLE
Allow comparison with intmax_t and uintmax_t types

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,22 @@ Changes in 0.3:
  * Added ZT_CMP_PTR for comparing pointers for equality and inequality.
    Other relations are explicitly left out, at least for now.
 
+ * ZT_CMP_INT and ZT_CMP_UINT now support maximum integral types of the
+   architecture. This allows ZT_CMP_UINT to safely work with size_t values.
+
+   This is achieved in a backwards compatible way. Existing test programs
+   compiled and linked with libzt 0.1 or 0.2 retain their current semantic.
+
+   The type zt_value has grown two new kinds, ZT_INTMAX and ZT_UINTMAX,
+   along with new union members. The static inline pack functions
+   zt_pack_integer and zt_pack_unsigned now take intmax_t and uintmax_t
+   arguments respectively. Since they are always inlined this is not an
+   ABI break. Test programs built with older definitions of the two pack
+   functions use distinct kind (ZT_INTEGER instead of ZT_INTMAX and
+   ZT_UNSIGNED instead of ZT_UINTMAX) which is now detected and handled
+   by zt_cmp_int and zt_cmp_uint. Internally the values are promoted
+   and comparison is always performed on the extended types.
+
 Changes in 0.2:
 
  * Argument type to all unit test functions was typedef'd

--- a/man/ZT_CMP_INT.3
+++ b/man/ZT_CMP_INT.3
@@ -67,5 +67,16 @@ The
 macro and the
 .Fn zt_cmp_int
 function first appeared in libzt 0.1
+.Pp
+Since libzt 0.3
+.Fn zt_cmp_int
+internally promotes
+.Nm left
+and
+.Nm right
+arguments from
+.Nm ZT_INTEGER
+to
+.Nm ZT_INTMAX .
 .Sh AUTHORS
 .An "Zygmunt Krynicki" Aq Mt me@zygoon.pl

--- a/man/ZT_CMP_UINT.3
+++ b/man/ZT_CMP_UINT.3
@@ -67,5 +67,16 @@ The
 macro and the
 .Fn zt_cmp_uint
 function first appeared in libzt 0.1
+.Pp
+Since libzt 0.3
+.Fn zt_cmp_uint
+internally promotes
+.Nm left
+and
+.Nm right
+arguments from
+.Nm ZT_UNSIGNED
+to
+.Nm ZT_UINTMAX .
 .Sh AUTHORS
 .An "Zygmunt Krynicki" Aq Mt me@zygoon.pl

--- a/man/zt_pack_integer.3
+++ b/man/zt_pack_integer.3
@@ -8,7 +8,7 @@
 .In zt.h
 .Ft zt_value
 .Fo zt_pack_integer
-.Fa "int value"
+.Fa "intmax_t value"
 .Fa "const char *source"
 .Fc
 .Sh DESCRIPTION
@@ -35,5 +35,15 @@ The packed value.
 .Sh HISTORY
 .Nm
 first appeared in libzt 0.1
+.Pp
+In libzt 0.3 the type of the first argument changed to
+.Nm intmax_t ,
+to accommodate for wider values. The resulting value structure encodes the
+new corresponding kind,
+.Nm ZT_INTMAX .
+Note that
+.Nm zt_value
+objects created by programs compiled with earlier versions of libzt
+are still valid and are internally promoted to the wider type.
 .Sh AUTHORS
 .An "Zygmunt Krynicki" Aq Mt me@zygoon.pl

--- a/man/zt_pack_unsigned.3
+++ b/man/zt_pack_unsigned.3
@@ -8,7 +8,7 @@
 .In zt.h
 .Ft zt_value
 .Fo zt_pack_unsigned
-.Fa "unsigned value"
+.Fa "uintmax_t value"
 .Fa "const char *source"
 .Fc
 .Sh DESCRIPTION
@@ -35,5 +35,15 @@ The packed value.
 .Sh HISTORY
 .Nm
 first appeared in libzt 0.1
+.Pp
+In libzt 0.3 the type of the first argument changed to
+.Nm uintmax_t ,
+to accommodate for wider values. The resulting value structure encodes the
+new corresponding kind,
+.Nm ZT_UINTMAX .
+Note that
+.Nm zt_value
+objects created by programs compiled with earlier versions of libzt
+are still valid and are internally promoted to the wider type.
 .Sh AUTHORS
 .An "Zygmunt Krynicki" Aq Mt me@zygoon.pl

--- a/man/zt_value.3
+++ b/man/zt_value.3
@@ -18,6 +18,8 @@
 .It Vt int Ta as.rune Ta Value when used as ZT_RUNE
 .It Vt const char * Ta as.string Ta Value when used as ZT_STRING
 .It Vt const void * Ta as.pointer Ta Value when used as ZT_POINTER
+.It Vt intmax_t Ta as.intmax Ta Value when used as ZT_INTMAX
+.It Vt uintmax_t Ta as.uintmax Ta Value when used as ZT_UINTMAX
 .El
 .Pp
 .Vt typedef enum zt_value_kind { ... } zt_value_kind;
@@ -25,11 +27,13 @@
 .It Sy Kind Ta Sy Description
 .It Vt ZT_NOTHING Ta Placeholder for unused values
 .It Vt ZT_BOOLEAN Ta zt_value.as.boolean is valid
-.It Vt ZT_INTEGER Ta zt_value.as.integer is valid
-.It Vt ZT_UNSIGNED Ta zt_value.as.unsigned_integer is valid
+.It Vt ZT_INTEGER Ta zt_value.as.integer is valid (deprecated)
+.It Vt ZT_UNSIGNED Ta zt_value.as.unsigned_integer is valid (deprecated)
 .It Vt ZT_RUNE Ta zt_value.as.rune is valid
 .It Vt ZT_STRING Ta zt_value.as.string is valid
 .It Vt ZT_POINTER Ta zt_value.as.pointer is valid
+.It Vt ZT_INTMAX Ta zt_value.as.intmax is valid
+.It Vt ZT_UINTMAX Ta zt_value.as.uintmax is valid
 .El
 .Sh DESCRIPTION
 .Nm zt_value
@@ -54,6 +58,20 @@ type and into private verification functions that determine test outcome.
 .Pp
 Tests using binary relations encode the operator as an argument of kind
 .Em ZT_STRING .
+.Sh BUGS
+On some architectures
+.Nm ZT_INTEGER
+and
+.Nm ZT_UNSIGNED
+are too short to handle
+.Nm size_t
+and
+.Nm ssize_t
+values correctly. They are now deprecated and automatically promoted to
+.Nm ZT_INTMAX
+and
+.Nm ZT_UINTMAX
+respectively.
 .Sh SEE ALSO
 .Xr zt_visit_test_case 3 ,
 .Xr zt_visit_test_suite 3
@@ -62,5 +80,9 @@ Tests using binary relations encode the operator as an argument of kind
 and
 .Nm zt_value_kind
 first appeared in libzt 0.1
+.Pp
+.Nm ZT_INTMAX ,
+.Nm ZT_UINTMAX
+and the corresponding union members first appeared in libzt 0.3.
 .Sh AUTHORS
 .An "Zygmunt Krynicki" Aq Mt me@zygoon.pl

--- a/zt.h
+++ b/zt.h
@@ -52,10 +52,12 @@ typedef enum zt_value_kind {
     ZT_NOTHING,
     ZT_BOOLEAN,
     ZT_RUNE, /* Rune is a more practical character type. */
-    ZT_INTEGER,
-    ZT_UNSIGNED,
+    ZT_INTEGER, /* Deprecated. Promoted to ZT_INTMAX */
+    ZT_UNSIGNED, /* Deprecated. Promoted to ZT_UINTMAX */
     ZT_STRING,
-    ZT_POINTER
+    ZT_POINTER,
+    ZT_INTMAX,
+    ZT_UINTMAX
 } zt_value_kind;
 
 typedef struct zt_value {
@@ -66,6 +68,8 @@ typedef struct zt_value {
         unsigned unsigned_integer;
         const char* string;
         const void* pointer;
+        intmax_t intmax;
+        uintmax_t uintmax;
     } as;
     const char* source;
     zt_value_kind kind;
@@ -91,21 +95,21 @@ static inline zt_value zt_pack_boolean(bool value, const char* source)
 
 zt_value zt_pack_rune(int value, const char* source);
 
-static inline zt_value zt_pack_integer(int value, const char* source)
+static inline zt_value zt_pack_integer(intmax_t value, const char* source)
 {
     zt_value v;
-    v.as.integer = value;
+    v.as.intmax = value;
     v.source = source;
-    v.kind = ZT_INTEGER;
+    v.kind = ZT_INTMAX;
     return v;
 }
 
-static inline zt_value zt_pack_unsigned(unsigned value, const char* source)
+static inline zt_value zt_pack_unsigned(uintmax_t value, const char* source)
 {
     zt_value v;
     v.source = source;
-    v.as.unsigned_integer = value;
-    v.kind = ZT_UNSIGNED;
+    v.as.uintmax = value;
+    v.kind = ZT_UINTMAX;
     return v;
 }
 


### PR DESCRIPTION
ZT_CMP_INT and ZT_CMP_UINT now support maximum integral types of the
architecture. This allows ZT_CMP_UINT to safely work with size_t values.

This is achieved in a backwards compatible way. Existing test programs
compiled and linked with libzt 0.1 or 0.2 retain their current semantic.

The type zt_value has grown two new kinds, ZT_INTMAX and ZT_UINTMAX,
along with new union members. The static inline pack functions
zt_pack_integer and zt_pack_unsigned now take intmax_t and uintmax_t
arguments respectively. Since they are always inlined this is not an
ABI break. Test programs built with older definitions of the two pack
functions use distinct kind (ZT_INTEGER instead of ZT_INTMAX and
ZT_UNSIGNED instead of ZT_UINTMAX) which is now detected and handled
by zt_cmp_int and zt_cmp_uint. Internally the values are promoted
and comparison is always performed on the extended types.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>