### PR TITLE
Fix libzt.map export of zt_cmp_ptr

### DIFF
--- a/libzt.map
+++ b/libzt.map
@@ -5,7 +5,6 @@ VERS_0_1 {
 		zt_cmp_bool;
 		zt_cmp_cstr;
 		zt_cmp_int;
-		zt_cmp_ptr;
 		zt_cmp_rune;
 		zt_cmp_uint;
 		zt_false;
@@ -18,3 +17,12 @@ VERS_0_1 {
 		zt_visit_test_suite;
 	local: *;
 };
+
+VERS_0_2 {
+
+} VERS_0_1;
+
+VERS_0_3 {
+	global:
+		zt_cmp_ptr;
+} VERS_0_2;


### PR DESCRIPTION
The function was added in upcoming libzt 0.3, not 0.1

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>