### PR TITLE
Handle PVS Studio license renewal

### DIFF
--- a/.makefiles/Makefile.UNIX.mk
+++ b/.makefiles/Makefile.UNIX.mk
@@ -237,7 +237,7 @@ clean::
 %.c.i: %.c
 	$(strip $(CC) $(CPPFLAGS) $< -E -o $@)
 
-%.c.PVS-Studio.log: %.c.i | %.c
+%.c.PVS-Studio.log: %.c.i ~/.config/PVS-Studio/PVS-Studio.lic | %.c
 	$(strip pvs-studio \
 		--cfg $(srcdir)/.pvs-studio.cfg \
 		--i-file $< \


### PR DESCRIPTION
When PVS Studio license expires, the *.PVS-Studio.log files are created
with information, that the license is stale and needs renewal.
Once the license is updated, those files stay stale, and require a
manual "make clean && make" cycle to correct.

This patch fixes that by putting modelling the dependency explicitly.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>