### PR TITLE
Add initial build support for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,10 +33,12 @@ build-*
 
 # Object files
 *.o
+*.obj
 
-# static libraries
+# static libraries and associated artefacts
 *.a
 *.lib
+*.exp
 
 # shared libraries and plugins
 *.dll

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,6 @@
+@echo off
+set CL=/nologo /Wall /wd4820 /wd4100 /wd4996 /wd4710 /wd5045
+cl /c zt.c
+cl /c zt-test.c
+cl zt-test.obj /Fe: libzt-test.exe
+cl /LD /DEF libzt.def zt.obj /Fe: zt.dll

--- a/libzt.def
+++ b/libzt.def
@@ -1,0 +1,19 @@
+LIBRARY ZT
+VERSION 0.3
+EXPORTS
+	zt_assert
+	zt_check
+	zt_cmp_bool
+	zt_cmp_cstr
+	zt_cmp_int
+	zt_cmp_ptr
+	zt_cmp_rune
+	zt_cmp_uint
+	zt_false
+	zt_main
+	zt_not_null
+	zt_null
+	zt_pack_rune
+	zt_true
+	zt_visit_test_case
+	zt_visit_test_suite


### PR DESCRIPTION
Windows build support is pretty preliminary as I'm not accustomed to how
anything works in this environment. The build.bat script can build a
working self-test and library, assuming it is invoked from the visual
studio prompt window. The export file defines the set of public symbols,
that matches other platforms.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>