### PR TITLE
Add GitHub CI for MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,20 @@ jobs:
       run: make
     - name: Run various checks
       run: make check
+  macos:
+    runs-on: macos-latest
+    needs: linux
+    steps:
+    - uses: actions/checkout@v2
+    - name: Configure
+      run: ./configure
+    - name: Build with Make
+      run: make
+    - name: Run various checks
+      run: make check
   windows:
     runs-on: windows-latest
+    needs: linux
     steps:
       - uses: actions/checkout@v2
       - uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
The MacOS job is identical to the Linux counterpart. I could have used
the strategy matrix but I'd like to have "needs: linux", to preserve
resources on things that fail on Linux anyway.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>