### PR TITLE
Fix MSVC build warnings

### DIFF
--- a/zt-test.c
+++ b/zt-test.c
@@ -110,9 +110,13 @@ static void selftest_quote_str(FILE* stream, const char* str)
     /* self-test quote function uses single-quotes. Meanwhile the production
      * quote function uses double quotes. This allows one to quote the other
      * without unnecessary escaping. */
-    int c;
     fputs("\'", stream);
-    while ((c = *(str++))) {
+    for (;;) {
+        int c = *str;
+        if (c == '\0') {
+            break;
+        }
+        str++;
         switch (c) {
         case '\'':
             fputs("\\'", stream);

--- a/zt.c
+++ b/zt.c
@@ -228,9 +228,13 @@ static void zt_quote_rune(FILE* stream, int c)
 
 static void zt_quote_string(FILE* stream, const char* str)
 {
-    int c;
     fputs("\"", stream);
-    while ((c = *(str++))) {
+    for (;;) {
+        int c = *str;
+        str++;
+        if (c == '\0') {
+            break;
+        }
         zt_quote_rune_inner(stream, c, '"');
     }
     fputs("\"", stream);


### PR DESCRIPTION
MSVC doesn't like while ((c = *(str++)) { ... }, use equivalent
logic without assignment in the while condition.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>