### PR TITLE
Teach the build system about various compilers

### DIFF
--- a/.makefiles/Makefile.Linux.mk
+++ b/.makefiles/Makefile.Linux.mk
@@ -21,6 +21,8 @@ include $(srcdir)/.makefiles/Makefile.UNIX.mk
 # TODO: add code coverage support
 libzt-test: LDFLAGS += -fPIE
 
+# Watcom doesn't build dynamic libraries.
+ifneq ($(_cc_kind),watcom)
 # Build and install the dynamic library.
 all:: libzt.so.1
 clean::
@@ -34,7 +36,10 @@ uninstall::
 # used in shared libraries.
 %.o: CFLAGS += -fPIC
 libzt.so.1: LDFLAGS += -shared -fvisibility=hidden
-libzt.so.1: LDFLAGS += -Wl,-soname=libzt.so.1 -Wl,--version-script=$(srcdir)/libzt.map
+libzt.so.1: LDFLAGS += -Wl,-soname=libzt.so.1
+ifneq ($(_cc_kind),tcc)
+libzt.so.1: LDFLAGS += -Wl,--version-script=$(srcdir)/libzt.map
+endif
 libzt.so.1: zt.o
 libzt.so.1: zt.o $(srcdir)/libzt.map
 	$(strip $(LINK.o) $(filter %.o,$^) $(LDLIBS) -o $@)
@@ -44,3 +49,5 @@ $(DESTDIR)$(libdir)/libzt.so.1: libzt.so.1 | $(DESTDIR)$(libdir)
 	install $^ $@
 $(DESTDIR)$(libdir)/libzt.so: | $(DESTDIR)$(libdir)/libzt.so.1
 	ln -s $(notdir $|) $@
+
+endif # !watcom

--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,10 @@ Changes in 0.3:
    Note that libzt-test.exe requires the DOS extender as it is too large to fit
    into 64K code segment.
 
+ * The configuration system is more robust and can now detect the use of Gcc,
+   Clang and the OpenWatcom compilers. Using OpenWatcom from the open-watcom
+   snap allows cross-compiling libzt for DOS and other older targets.
+
 Changes in 0.2:
 
  * Argument type to all unit test functions was typedef'd

--- a/configure
+++ b/configure
@@ -68,6 +68,7 @@
     test -n "$CXXFLAGS" && echo "CXXFLAGS=$CXXFLAGS"
     test -n "$CPPFLAGS" && echo "CPPFLAGS=$CPPFLAGS"
     test -n "$LDFLAGS" && echo "LDFLAGS=$LDFLAGS"
+    echo CONFIGURED=yes
 } > GNUmakefile.configure.mk
 
 if [ ! -e GNUmakefile ]; then


### PR DESCRIPTION
The build system had a naive expectation that each system is used
for native builds and that the default or preferred compiler of each
system is always used.

In order to support cross-compiling, or more generally, using custom
compilers. In addition some compilers support only certain features,
like being able to build a shared library but not to define the linker
export map. This patch makes the build system understand gcc, clang,
open watcom and bcc.

An build that has not used the configure script will now gain "curated"
options appropriate for each compiler.

Unless configured default to -Werror

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>