### PR TITLE
Add support for GNU/Hurd

### DIFF
--- a/.makefiles/Makefile.GNU.mk
+++ b/.makefiles/Makefile.GNU.mk
@@ -1,0 +1,18 @@
+# Copyright 2019-2020 Zygmunt Krynicki.
+#
+# This file is part of libzt.
+#
+# Libzt is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# Libzt is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Libzt.  If not, see <https://www.gnu.org/licenses/>.
+
+# Plot twist!
+include $(srcdir)/.makefiles/Makefile.Linux.mk


### PR DESCRIPTION
Ironically GNU/Hurd compiles with the same makefile that Linux currently
does. I should probably unify that somehow.

Fixes #30

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>