### PR TITLE
Add integration tests using spread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ GNUmakefile.configure.mk
 
 # Manual pages
 man/*.[123456789]
+
+# Spread
+.spread-reuse.yaml

--- a/NEWS
+++ b/NEWS
@@ -39,6 +39,11 @@ Changes in 0.3:
    become a new development-only dependency. Distribution tarballs will not
    require any new dependencies.
 
+ * The tree now contains comprehensive integration tests that build and
+   exercise the library on several different Linux distributions. One of the
+   tests cross builds libzt for DOS and tests it with DosBox and DOS/32
+   extender.
+
 Changes in 0.2:
 
  * Argument type to all unit test functions was typedef'd

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,129 @@
+project: libzt
+path: /root/libzt
+backends:
+  lxd:
+    systems:
+      - ubuntu-14.04
+      - ubuntu-16.04
+      - ubuntu-18.04
+      - ubuntu-20.04
+      - debian-10:
+          environment:
+            PATH: $PATH:/snap/bin
+      - debian-sid:
+          environment:
+            PATH: $PATH:/snap/bin
+      - fedora-31:
+          # FIXME: Fedora and CentOS are disabled because I cannot figure out how to proxy their archives correctly.
+          manual: true
+          environment:
+            PATH: $PATH:/var/lib/snapd/snap/bin:/snap/bin
+      - centos-7:
+          manual: true
+          environment:
+            PATH: $PATH:/var/lib/snapd/snap/bin:/snap/bin
+      - centos-8:
+          manual: true
+          environment:
+            PATH: $PATH:/var/lib/snapd/snap/bin:/snap/bin
+environment:
+    MAKEFLAGS: --warn-undefined-variables
+    PKG_PROXY: "$(HOST: echo \"$PKG_PROXY\")"
+prepare: |
+  # Establish consistent ownership
+  chown -R root.root $SPREAD_PATH
+  # Install dependencies
+  case $SPREAD_SYSTEM in
+    ubuntu-*)
+      test -n "$PKG_PROXY" && ( echo "Acquire::HTTP::Proxy \"$PKG_PROXY\";" >/etc/apt/apt.conf.d/00proxy )
+      apt-get update
+      apt-get install -y eatmydata
+      eatmydata apt-get install -y make gcc clang tree
+      ;;
+    debian-*)
+      test -n "$PKG_PROXY" && ( echo "Acquire::HTTP::Proxy \"$PKG_PROXY\";" >/etc/apt/apt.conf.d/00proxy )
+      apt-get update
+      apt-get install -y eatmydata
+      eatmydata apt-get install -y make gcc clang tree
+      ;;
+    fedora-*)
+      test -n "$PKG_PROXY" && ( echo "proxy=$PKG_PROXY" >>/etc/yum.conf)
+      dnf install -y make gcc clang tree
+      ;;
+    centos-*)
+      test -n "$PKG_PROXY" && ( echo "proxy=$PKG_PROXY" >>/etc/yum.conf)
+      yum install -y make gcc clang tree
+      ;;
+  esac
+  # Clean the project tree
+  make distclean
+restore: |
+  case $SPREAD_SYSTEM in
+    ubuntu-*|debian-*)
+      eatmydata apt-get remove -y --purge make gcc clang tree
+      apt-get autoremove -y --purge
+      ;;
+    fedora-*)
+      dnf remove -y make gcc clang tree
+      ;;
+    centos-*)
+      dnf remove -y make gcc clang tree
+      ;;
+  esac
+suites:
+  tests/build/:
+    summary: Build with various configurations
+  tests/use/:
+    prepare: |
+      $SPREAD_PATH/configure
+      make
+      make install
+      ldconfig
+    restore: |
+      make uninstall
+      ldconfig
+    summary: Use the library in practice
+  tests/snaps/:
+    summary: Test suite that depends on snapd
+    systems: [-ubuntu-14.04] # snapd doesn't work in Ubuntu 14.04 container
+    prepare: |
+      # Work around snapd bug in containers
+      mount --make-rshared /
+      # Install dependencies
+      case $SPREAD_SYSTEM in
+        ubuntu-*)
+          eatmydata apt-get install -y fuse squashfuse dosbox
+          ;;
+        debian-*)
+          eatmydata apt-get install -y fuse squashfuse dosbox snapd
+          ;;
+        fedora-*)
+          dnf install -y snapd squashfuse dosbox
+          ;;
+        centos-*)
+          yum install -y snapd squashfuse dosbox
+          ;;
+      esac
+      # Disable parallel-instances: https://bugs.launchpad.net/snapd/+bug/1873701
+      snap set core experimental.parallel-instances=false
+      # Install the core snap, this gets us most recent snapd
+      for _ in $(seq 3); do snap install core && break; done
+      snap list core
+    restore: |
+      case $SPREAD_SYSTEM in
+        ubuntu-*)
+          eatmydata apt-get remove -y --purge fuse squashfuse dosbox
+          apt-get autoremove -y --purge
+          ;;
+        debian-*)
+          rm -rf /var/cache/snapd/aux
+          eatmydata apt-get remove -y --purge fuse squashfuse snapd dosbox
+          apt-get autoremove -y --purge
+          ;;
+        fedora-*)
+          dnf remove -y snapd squashfuse dosbox
+          ;;
+        centos-*)
+          dnf remove -y snapd squashfuse dosbox
+          ;;
+      esac

--- a/tests/build/clang/task.yaml
+++ b/tests/build/clang/task.yaml
@@ -1,0 +1,8 @@
+summary: Configure, build and test with clang
+prepare: |
+  $SPREAD_PATH/configure CC=clang
+execute: |
+  make
+  make check
+restore: |
+  make clean

--- a/tests/build/cross/task.yaml
+++ b/tests/build/cross/task.yaml
@@ -1,0 +1,33 @@
+summary: Cross-build with gcc
+systems: [debian-sid]
+environment:
+    TRIPLET/x32: x86_64-linux-gnux32
+    PKG/x32: gcc-x86-64-linux-gnux32
+    FILE/x32: "ELF 32-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /libx32/ld-linux-x32.so.2,"
+
+    TRIPLET/armhf: arm-linux-gnueabihf
+    PKG/armhf: gcc-arm-linux-gnueabihf
+    FILE/armhf: "ELF 32-bit LSB shared object, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3,"
+
+    TRIPLET/aarch64: aarch64-linux-gnu
+    PKG/aarch64: gcc-aarch64-linux-gnu
+    FILE/aarch64: "ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1,"
+
+    TRIPLET/powerpc64le: powerpc64le-linux-gnu
+    PKG/powerpc64le: gcc-powerpc64le-linux-gnu
+    FILE/powerpc64le: "ELF 64-bit LSB shared object, 64-bit PowerPC or cisco 7500, version 1 (SYSV), dynamically linked, interpreter /lib64/ld64.so.2,"
+
+    TRIPLET/riscv64: riscv64-linux-gnu
+    PKG/riscv64: gcc-riscv64-linux-gnu
+    FILE/riscv64: "ELF 64-bit LSB shared object, UCB RISC-V, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-riscv64-lp64d.so.1,"
+prepare: |
+    apt-get install --yes $PKG
+    $SPREAD_PATH/configure --build=$(dpkg-architecture -qDEB_HOST_GNU_TYPE) --host=$TRIPLET
+execute: |
+  make
+  file libzt-test | grep -F "$FILE"
+  make check
+restore: |
+  make clean
+  apt-get remove --yes --purge $PKG 
+  apt-get autoremove --yes

--- a/tests/build/dpkg-buildflags/task.yaml
+++ b/tests/build/dpkg-buildflags/task.yaml
@@ -1,0 +1,8 @@
+summary: Configure, build and test with dpkg-buildflags
+prepare: |
+  $SPREAD_PATH/configure $(dpkg-buildflags --export=configure)
+execute: |
+  make
+  make check
+restore: |
+  make clean

--- a/tests/build/gcc/task.yaml
+++ b/tests/build/gcc/task.yaml
@@ -1,0 +1,8 @@
+summary: Configure, build and test with gcc
+prepare: |
+  $SPREAD_PATH/configure CC=gcc
+execute: |
+  make
+  make check
+restore: |
+  make clean

--- a/tests/build/install/expected.tree
+++ b/tests/build/install/expected.tree
@@ -1,0 +1,45 @@
+.
+└── usr
+    └── local
+        ├── bin
+        │   └── libzt-test
+        ├── include
+        │   └── zt.h
+        ├── lib
+        │   ├── libzt.a
+        │   ├── libzt.so -> libzt.so.1
+        │   └── libzt.so.1
+        └── share
+            └── man
+                ├── man1
+                │   └── libzt-test.1
+                └── man3
+                    ├── ZT_CMP_BOOL.3
+                    ├── ZT_CMP_INT.3
+                    ├── ZT_CMP_PTR.3
+                    ├── ZT_CMP_RUNE.3
+                    ├── ZT_CMP_UINT.3
+                    ├── ZT_CURRENT_LOCATION.3
+                    ├── ZT_FALSE.3
+                    ├── ZT_NOT_NULL.3
+                    ├── ZT_NULL.3
+                    ├── ZT_TRUE.3
+                    ├── libzt.3
+                    ├── zt_check.3
+                    ├── zt_claim.3
+                    ├── zt_location.3
+                    ├── zt_location_at.3
+                    ├── zt_main.3
+                    ├── zt_pack_boolean.3
+                    ├── zt_pack_integer.3
+                    ├── zt_pack_nothing.3
+                    ├── zt_pack_pointer.3
+                    ├── zt_pack_rune.3
+                    ├── zt_pack_string.3
+                    ├── zt_pack_unsigned.3
+                    ├── zt_test.3
+                    ├── zt_test_case_func.3
+                    ├── zt_test_suite_func.3
+                    ├── zt_value.3
+                    ├── zt_visit_test_case.3
+                    └── zt_visitor.3

--- a/tests/build/install/task.yaml
+++ b/tests/build/install/task.yaml
@@ -1,0 +1,10 @@
+summary: Configure, build and install
+prepare: |
+  $SPREAD_PATH/configure
+execute: |
+  make
+  make install DESTDIR=$(pwd)/fs
+  (cd fs && tree --charset=utf-8 -v --noreport .) > actual.tree
+  diff -u actual.tree expected.tree
+restore: |
+  make clean

--- a/tests/build/tcc/task.yaml
+++ b/tests/build/tcc/task.yaml
@@ -1,0 +1,12 @@
+summary: Configure, build and test with tcc
+systems: [ubuntu-*, debian-*]
+prepare: |
+  apt-get install -y tcc
+  $SPREAD_PATH/configure CC=tcc
+execute: |
+  make
+  make check
+restore: |
+  make clean
+  apt-get remove -y --purge tcc
+  apt-get autoremove -y --purge

--- a/tests/build/uninstall/expected.tree
+++ b/tests/build/uninstall/expected.tree
@@ -1,0 +1,10 @@
+.
+└── usr
+    └── local
+        ├── bin
+        ├── include
+        ├── lib
+        └── share
+            └── man
+                ├── man1
+                └── man3

--- a/tests/build/uninstall/task.yaml
+++ b/tests/build/uninstall/task.yaml
@@ -1,0 +1,11 @@
+summary: Configure, build, install then uninstall
+prepare: |
+  $SPREAD_PATH/configure
+execute: |
+  make
+  make install DESTDIR=$(pwd)/fs
+  make uninstall DESTDIR=$(pwd)/fs
+  (cd fs && tree --charset=utf-8 -v --noreport .) > actual.tree
+  diff -u actual.tree expected.tree
+restore: |
+  make clean

--- a/tests/snaps/open-watcom-dos4g/expected.dos
+++ b/tests/snaps/open-watcom-dos4g/expected.dos
@@ -1,0 +1,1 @@
+libzt self-test successful

--- a/tests/snaps/open-watcom-dos4g/task.yaml
+++ b/tests/snaps/open-watcom-dos4g/task.yaml
@@ -1,0 +1,18 @@
+summary: Configure, build and test with open-watcom
+prepare: |
+  snap install --beta open-watcom
+  snap install dos32a
+  cp /snap/dos32a/current/binw/dos32a.exe DOS4GW.EXE
+  $SPREAD_PATH/configure CC=open-watcom.owcc-dos4g
+execute: |
+  make
+  test -e libzt-test.exe && mv libzt-test.exe zt-test.exe
+  test -e libzt-test && mv libzt-test zt-test.exe
+  SDL_VIDEODRIVER=dummy dosbox -c 'MOUNT C .' -c 'C:' -c 'zt-test.exe >ACTUAL.DOS' -c 'exit'
+  diff -u ACTUAL.DOS expected.dos
+restore: |
+  make clean
+  snap remove --purge open-watcom
+  snap remove --purge dos32a
+  rm -f DOS4GW.EXE
+  rm -rf ~/.dosbox

--- a/tests/snaps/open-watcom-linux/task.yaml
+++ b/tests/snaps/open-watcom-linux/task.yaml
@@ -1,0 +1,10 @@
+summary: Configure, build and test with open-watcom 
+prepare: |
+  snap install --beta open-watcom
+  $SPREAD_PATH/configure CC=open-watcom.owcc-linux
+execute: |
+  make
+  make check
+restore: |
+  make clean
+  snap remove --purge open-watcom

--- a/tests/use/examples/demo.expected.stderr
+++ b/tests/use/examples/demo.expected.stderr
@@ -1,0 +1,5 @@
+<<SPREAD_PATH>>/examples/demo.c:17: assertion failed because 2 + 2 != 4 is false
+<<SPREAD_PATH>>/examples/demo.c:18: assertion failed because 2 + 2 != 5 is true
+<<SPREAD_PATH>>/examples/demo.c:19: assertion 2 + 2 == 5 failed because 4 != 5
+<<SPREAD_PATH>>/examples/demo.c:20: assertion false == true failed because false != true
+<<SPREAD_PATH>>/examples/demo.c:25: assertion 0 == -1 failed because 0 != -1

--- a/tests/use/examples/task.yaml
+++ b/tests/use/examples/task.yaml
@@ -1,0 +1,15 @@
+summary: Build and run examples
+prepare: |
+    make -f $SPREAD_PATH/examples/GNUmakefile VPATH=$SPREAD_PATH/examples
+execute: |
+    # Demo works
+    ! ./demo >demo.actual.stdout 2>demo.actual.stderr
+    sed -i -e "s@$SPREAD_PATH@<<SPREAD_PATH>>@g" demo.actual.stderr
+    diff -u demo.actual.stdout demo.expected.stdout
+    diff -u demo.actual.stderr demo.expected.stderr
+    # Demo is dynamically linked
+    ldd demo | MATCH libzt
+    # The other example also works
+    ./test-root-user
+restore: |
+    make -f $SPREAD_PATH/examples/GNUmakefile VPATH=$SPREAD_PATH/examples clean


### PR DESCRIPTION
The tests cover pretty much everything that the library and the build
system offers. You need to use LXD and spread to run them. If you want
to test non-Ubuntu targets you need to apply a patch to spread.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>